### PR TITLE
chore: add auto-merge workflow and update PHP to 8.5

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,12 @@
+name: Auto-merge dependency PRs
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
         }
     ],
     "require": {
-        "php": "5.3 - 7.0",
+        "php": ">=8.5",
         "pear/console_commandline": "^1.1",
         "pear/config": "*",
         "pear/system_folders": "dev-master"
     },
     "config": {
         "platform": {
-            "php": "5.3"
+            "php": "8.5"
         }
     },
     "bin": [


### PR DESCRIPTION
## Summary
- Add caller to `netresearch/.github` auto-merge-deps.yml reusable workflow
- Update PHP requirement to 8.5 (latest)
- Supersedes closed PRs #6 (PHP 7.4.33) and #7 (PHP 8)
- Repo `allow_auto_merge` has been enabled

## Test plan
- [ ] Verify PHP 8.5 compatibility
- [ ] Verify auto-merge triggers on next dependency PR